### PR TITLE
Add wrapper for vips_image_new_from_memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ Those are basically safe wrappers on top of the also genereated bindings. Though
 
 Both the bindings and the generated operations were pushed to crates.io with most of optional dependencies from libvips included. Be careful when calling functions that are dependent on those sub-dependencies (most of them format related).
 
+### Contributing
+
+Everything in ops.rs and error.rs (and of course bindings.rs) is generated programmatically. You need to make changes for these files to the builder for these. Then, run the following shell scripts from the `generator` directory.
+
+```
+$ ./build.sh     # Builds the libvips-builder docker image
+$ ./generate.sh  # Actually generates the bindings
+```
+
 ## How to use it
 
 The main entity from this crate is the `VipsApp` struct. It doesn't store any information, but as long as it is not dropped, vips should be working as expected.

--- a/generator/build.rs
+++ b/generator/build.rs
@@ -804,7 +804,7 @@ impl ParamType {
                     .join("\n");
                 format!(
                     r#"
-                #[derive(Copy, Clone, Debug, FromPrimitive)]
+                #[derive(Copy, Clone, Debug, FromPrimitive, ToPrimitive)]
                 pub enum {} {{
                     {}
                 }}

--- a/src/image.rs
+++ b/src/image.rs
@@ -4,7 +4,7 @@ use crate::ops::*;
 use crate::utils;
 use crate::Result;
 
-use num_traits::FromPrimitive;
+use num_traits::{FromPrimitive, ToPrimitive};
 use std::ffi::*;
 use std::ptr::null_mut;
 use std::mem;
@@ -115,6 +115,27 @@ impl VipsImage {
                 res,
                 Error::InitializationError("Could not initialise VipsImage from file"),
             )
+        }
+    }
+
+    pub fn image_new_from_memory(buffer: &[u8], width: i32, height: i32, bands: i32, format: BandFormat) -> Result<VipsImage> {
+        unsafe {
+            if let Some(format) = format.to_i32() {
+                let res = bindings::vips_image_new_from_memory(
+                    buffer.as_ptr() as *const c_void,
+                    buffer.len() as u64,
+                    width,
+                    height,
+                    bands,
+                    format
+                );
+                vips_image_result(
+                    res,
+                    Error::InitializationError("Could not initialise VipsImage from file"),
+                )
+            } else {
+                Err(Error::InitializationError("Invalid BandFormat. Please file a bug report, as this should never happen."))
+            }
         }
     }
 

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -74,7 +74,7 @@ pub enum Angle45 {
     Last = 8,
 }
 
-#[derive(Copy, Clone, Debug, FromPrimitive)]
+#[derive(Copy, Clone, Debug, FromPrimitive, ToPrimitive)]
 pub enum BandFormat {
     ///  `Notset` -> VIPS_FORMAT_NOTSET = -1
     Notset = -1,


### PR DESCRIPTION
Hey, thanks for making these bindings!

I noticed that the constructor dealing with things like raw RGBA buffers was missing, so I've added a wrapper to expose it.